### PR TITLE
use different cache sizes based on environment #1163

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM kong:0.10.3
 
 COPY ndla-run-kong.sh /ndla-run-kong.sh
 COPY nginx.template /nginx.template
+COPY nginx-caches-prod.conf nginx-caches-default.conf /
 RUN chmod +x /ndla-run-kong.sh
 
 RUN yum --assumeyes install python-pip jq && \

--- a/ndla-run-kong.sh
+++ b/ndla-run-kong.sh
@@ -28,12 +28,20 @@ function setup_logging {
     cat <> /tmp/logpipe 1>&2 &
 }
 
+function setup_nginx_caches {
+    case $NDLA_ENVIRONMENT in
+	    prod | staging) ln -fs /nginx-caches-prod.conf /nginx-caches.conf;;
+	    *) ln -fs /nginx-caches-default.conf /nginx-caches.conf;;
+    esac
+}
+
 if [ "$NDLA_ENVIRONMENT" != "local" ]
 then
     prepare_remote
 fi
 
 setup_logging
+setup_nginx_caches
 
 export KONG_PROXY_LISTEN=0.0.0.0:8000
 kong start --nginx-conf /nginx.template

--- a/nginx-caches-default.conf
+++ b/nginx-caches-default.conf
@@ -1,0 +1,2 @@
+proxy_cache_path /tmp/nginx_cache levels=1:2 keys_zone=image_cache:100M max_size=2G inactive=40d;
+proxy_cache_path /tmp/nginx_resp_cache levels=1:2 keys_zone=api_response_cache:100M max_size=2G;

--- a/nginx-caches-prod.conf
+++ b/nginx-caches-prod.conf
@@ -1,0 +1,2 @@
+proxy_cache_path /tmp/nginx_cache levels=1:2 keys_zone=image_cache:1024M max_size=2G inactive=40d;
+proxy_cache_path /tmp/nginx_resp_cache levels=1:2 keys_zone=api_response_cache:2048M max_size=2G;

--- a/nginx.template
+++ b/nginx.template
@@ -8,8 +8,8 @@ env NDLA_ENVIRONMENT;
 events {}
 
 http {
-    proxy_cache_path /tmp/nginx_cache levels=1:2 keys_zone=image_cache:10M max_size=2G inactive=40d;
-    proxy_cache_path /tmp/nginx_resp_cache levels=1:2 keys_zone=api_response_cache:2048M max_size=2G;
+    # include cache definitions used in the server blocks below
+    include '/nginx-caches.conf';
 
     # include default Kong Nginx config
     include 'nginx-kong.conf';


### PR DESCRIPTION
Jeg var visst litt kjapp med forrige PR. Testa lokalt og i test, og det gikk fint. staging fungerte ikke, da den ikke hadde nok ram ift. cache størrelser.
Denne PRen endrer slik at cache størrelser i nginx bestemmes basert på miljønavn (via startup scriptet).
Staging og prod har ikke så mye minne tilgjengelig enda, men kommer til å få ganske snart