### PR TITLE
Fixes header config for cached requests

### DIFF
--- a/nginx.template
+++ b/nginx.template
@@ -31,11 +31,6 @@ http {
             proxy_cache_use_stale error invalid_header timeout updating;
             proxy_cache_bypass  $http_cache_control;
 
-            proxy_set_header  Host $http_host;
-            proxy_set_header  X-Real-IP $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header  Forwarded "for=$remote_addr;proto=$http_x_forwarded_proto";
-
             proxy_pass $http_upstream_url;
         }
     }
@@ -145,7 +140,8 @@ http {
           proxy_set_header  Host $http_host;
           proxy_set_header  X-Real-IP $remote_addr;
           proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header  Forwarded "for=$remote_addr;proto=$http_x_forwarded_proto";
+          proxy_set_header  X-Forwarded-Proto $proxy_add_x_forwarded_proto;
+          proxy_set_header  Forwarded "for=$remote_addr;proto=$proxy_add_x_forwarded_proto";
           proxy_set_header  X-Forwarded-Prefix /$1;
           proxy_pass http://$api_gateway;
         }


### PR DESCRIPTION
Dette fikser bare at `Forwarded` headeren ikke blir oppdatert med feil verdier fra Kong.
Så apiene vil fungere riktig igjen.
`X-Forwarded-Proto` vil fikses når vi oppgraderer kong (https://github.com/Kong/kong/issues/2202).