### PR TITLE
#1575: Adds X-Forwarded-Host that components can use rather than Host header

### DIFF
--- a/nginx.template
+++ b/nginx.template
@@ -64,6 +64,7 @@ http {
           proxy_set_header  Host $http_host;
           proxy_set_header  X-Real-IP $remote_addr;
           proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header  X-Forwarded-Host $http_host;
           proxy_set_header  Forwarded "for=$remote_addr;proto=$http_x_forwarded_proto";
           proxy_set_header  X-Forwarded-Prefix /$1;
           proxy_pass http://$api_gateway;
@@ -102,6 +103,7 @@ http {
           proxy_set_header  Host $http_host;
           proxy_set_header  X-Real-IP $remote_addr;
           proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header  X-Forwarded-Host $http_host;
           proxy_set_header  Forwarded "for=$remote_addr;proto=$http_x_forwarded_proto";
           proxy_set_header  X-Forwarded-Prefix /$1;
 
@@ -140,6 +142,7 @@ http {
           proxy_set_header  X-Real-IP $remote_addr;
           proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header  X-Forwarded-Proto $http_x_forwarded_proto;
+          proxy_set_header  X-Forwarded-Host $http_host;
           proxy_set_header  Forwarded "for=$remote_addr;proto=$http_x_forwarded_proto";
           proxy_set_header  X-Forwarded-Prefix /$1;
           proxy_pass http://$api_gateway;


### PR DESCRIPTION
connects to NDLANO/Issues#1575

Linkerd service meshet bruker host headeren så da kan komponentene heller bruker `X-Forwarded-Host` også kan vi droppe preserve-path (Den siste biten fikses i deploy).