### PR TITLE
#1711: Upgrades kong to 1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong:0.14.1-alpine
+FROM kong:1.2.0-alpine
 
 COPY ndla-run-kong.sh /ndla-run-kong.sh
 COPY nginx.template /nginx.template


### PR DESCRIPTION
Shouldn't be deployed without first running migrations