### PR TITLE
Include feide authorization in cache_key for response caching

### DIFF
--- a/nginx-api-cache.conf
+++ b/nginx-api-cache.conf
@@ -1,5 +1,5 @@
 proxy_cache api_response_cache;
-proxy_cache_key "$proxy_host$uri$is_args$args";
+proxy_cache_key "$http_feideauthorization$proxy_host$uri$is_args$args";
 proxy_cache_lock on;
 proxy_cache_use_stale error invalid_header timeout updating;
 proxy_cache_bypass  $http_cache_control;


### PR DESCRIPTION
Dette gjør at i praksis folk som har `FeideAuthorization` får sin egen cache.