### PR TITLE
Worker connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN chmod +x /ndla-run-kong.sh
 
 RUN apt-get update && apt-get install curl -y
 
-ENV KONG_PROXY_ACCESS_LOG /dev/stdout
-ENV KONG_ADMIN_ACCESS_LOG /dev/stdout
-ENV KONG_PROXY_ERROR_LOG /dev/stderr
-ENV KONG_ADMIN_ERROR_LOG /dev/stderr
+ENV KONG_PROXY_ACCESS_LOG=/dev/stdout
+ENV KONG_ADMIN_ACCESS_LOG=/dev/stdout
+ENV KONG_PROXY_ERROR_LOG=/dev/stderr
+ENV KONG_ADMIN_ERROR_LOG=/dev/stderr
 
-CMD ./ndla-run-kong.sh
+CMD [ "./ndla-run-kong.sh" ]
 

--- a/ndla-run-kong.sh
+++ b/ndla-run-kong.sh
@@ -24,6 +24,10 @@ function setup_dns_resolver {
 setup_nginx_caches
 setup_dns_resolver
 
+if [ -z "$KONG_NGINX_EVENTS_WORKER_CONNECTIONS" ]; then
+    export KONG_NGINX_EVENTS_WORKER_CONNECTIONS="2048"
+fi
+
 export KONG_CLUSTER_ADVERTISE=$(hostname -i):7946
 export KONG_PROXY_LISTEN=0.0.0.0:8000
 export KONG_ADMIN_LISTEN=0.0.0.0:8001

--- a/nginx.template
+++ b/nginx.template
@@ -11,7 +11,9 @@ env IMAGE_FILE_S3_BUCKET;
 env AUDIO_FILE_S3_BUCKET;
 env ARTICLE_ATTACHMENT_S3_BUCKET;
 
-events {}
+events {
+    worker_connections ${{NGINX_EVENTS_WORKER_CONNECTIONS}};
+}
 
 http {
     # include cache definitions used in the server blocks below


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/4044

Legger til muligheten for å konfigurere `worker_connections` med miljøvariabel. Samt setter defaulten til å være 2048.

I følge det jeg researcha [her](https://github.com/NDLANO/Issues/issues/4044#issuecomment-2124154871) så skulle det vært noe bedre defaults, men ser ikke ut som de blir satt til noe annet enn 512 så, tenker vi kan manuelt justere den alikevel.