### PR TITLE
Set Content-Disposition header based on query parameter

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,5 +10,5 @@ then
     VERSION="SNAPSHOT"
 fi
 
-docker build -t $PROJECT:$VERSION .
+docker build -o type=docker -t $PROJECT:$VERSION .
 echo "BUILT $PROJECT:$VERSION"

--- a/ndla-run-kong.sh
+++ b/ndla-run-kong.sh
@@ -17,7 +17,8 @@ function setup_dns_resolver {
     if is_kubernetes; then # Check whether we are running on kubernetes or not
         echo "resolver kube-dns.kube-system.svc.cluster.local;" > /nginx-resolver.conf
     else
-        echo "resolver 127.0.0.11;" > /nginx-resolver.conf
+        RESOLVER=`grep "nameserver" /etc/resolv.conf | awk '{print $2}' | tr -d '\n'`
+        echo "resolver $RESOLVER;" > /nginx-resolver.conf
     fi
 }
 

--- a/nginx.template
+++ b/nginx.template
@@ -31,6 +31,12 @@ http {
     gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml application/json;
     gzip_disable msie6;
 
+    map $arg_download $files_content_disposition {
+        default "";
+        ""      "";
+        ~.+     "attachment; filename=\"$arg_download\"";
+    }
+
     server {
         listen 8080;
         server_name apicache;
@@ -164,6 +170,8 @@ http {
               return os.getenv("NDLA_ENVIRONMENT") .. ".article-attachments.ndla.s3.amazonaws.com"
             end
           }
+
+          add_header Content-Disposition $files_content_disposition;
 
           set $url_file         '$1';
 


### PR DESCRIPTION
Man kan visst ikke bruke query parametere for respons-header hvis man kjører anonyme GET kall til S3 (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html), så jeg endte i stedet med en egendefinert query param i NGINX